### PR TITLE
fix: Github action build fail (Issue#13)

### DIFF
--- a/BugCourt/src/main/java/com/sleepyjelly/pb/common/security/SecurityConfig.java
+++ b/BugCourt/src/main/java/com/sleepyjelly/pb/common/security/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.sleepyjelly.pb.common.security;
 
-import org.apache.catalina.User;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -19,12 +17,12 @@ import com.sleepyjelly.pb.common.user.UserRole;
 public class SecurityConfig {
 
     @Bean
-    public BCryptPasswordEncoder encoder() {
+    BCryptPasswordEncoder encoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     	http
 		.csrf((csrfConfig) ->
 				csrfConfig.disable()
@@ -36,7 +34,7 @@ public class SecurityConfig {
 		)
 		.authorizeHttpRequests((authorizeRequests) ->
 				authorizeRequests
-						.requestMatchers(PathRequest.toH2Console()).permitAll()
+//						.requestMatchers(PathRequest.toH2Console()).permitAll()
 						.requestMatchers("/", "/login/**").permitAll()
 						.requestMatchers("/bbs/**", "/toRoot/v1/bbs/**").hasAnyAuthority(UserRole.USER,UserRole.MEMBERSHIP_USER,UserRole.ADMIN)
 						.requestMatchers("/admins/**", "/toRoot/v1/admins/**").hasAnyAuthority(UserRole.ADMIN)
@@ -62,7 +60,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public CorsFilter corsFilter() {
+    CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
         config.addAllowedOrigin("http://localhost:5173");//  bug-court-react@0.0.0 dev 	 //	> vite

--- a/BugCourt/src/test/java/com/sleepyjelly/pb/BugCourtApplicationTestConfig.java
+++ b/BugCourt/src/test/java/com/sleepyjelly/pb/BugCourtApplicationTestConfig.java
@@ -1,0 +1,14 @@
+package com.sleepyjelly.pb;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class })
+public class BugCourtApplicationTestConfig {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BugCourtApplicationTestConfig.class, args);
+    }
+    
+}

--- a/BugCourt/src/test/java/com/sleepyjelly/pb/BugCourtApplicationTests.java
+++ b/BugCourt/src/test/java/com/sleepyjelly/pb/BugCourtApplicationTests.java
@@ -2,8 +2,9 @@ package com.sleepyjelly.pb;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
-@SpringBootTest
+@SpringBootTest(classes = BugCourtApplicationTestConfig.class, webEnvironment = WebEnvironment.DEFINED_PORT)
 class BugCourtApplicationTests {
 
 	@Test


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Works fine in local IDE, but throws an exception in GitHub Actions.

Even though I specified the datasource.url attribute in application.yml, GitHub Actions doesn't seem to read it properly, resulting in the following error: ->

Failed to configure a DataSource: 'url' attribute is not specified, and no embedded datasource could be configured.


## Related Tickets & Documents
-related ?
https://github.com/spring-projects/spring-boot/issues/15758
https://github.com/spring-projects/spring-boot/issues/33834


https://www.baeldung.com/spring-boot-exclude-auto-configuration-test 
->separate configuration application for our tests

- Related Issue #
#31 

- Closes #
#31 
